### PR TITLE
docs: clarify provider version constraints from modules

### DIFF
--- a/.skills/version-upgrades/SKILL.md
+++ b/.skills/version-upgrades/SKILL.md
@@ -202,8 +202,19 @@ hcptf <org> <workspace> runs $RUN_ID configversion
 
 **Update provider version in code:**
 
+> **Important**: Provider version constraints can come from multiple sources:
+> - **Root-level** `required_providers` blocks in your workspace code (you can update these directly)
+> - **Module-level** `required_providers` blocks in consumed modules (you CANNOT update these directly)
+>
+> If provider versions are declared within a module you're consuming, you must either:
+> 1. Update to a newer version of the module that supports the desired provider version
+> 2. Check the module's documentation/changelog for supported provider versions
+> 3. Fork and modify the module (not recommended for registry modules)
+>
+> Use `terraform init` output to identify where provider version constraints originate.
+
 ```hcl
-# In versions.tf or terraform block
+# In versions.tf or terraform block (ROOT-LEVEL ONLY)
 terraform {
   required_providers {
     aws = {
@@ -316,7 +327,12 @@ git checkout main
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-changelog
 
-# Edit versions.tf or terraform block:
+# IMPORTANT: Check where the provider version constraint comes from
+# Run `terraform init` to see if constraints are in your root config or in modules
+# If the version is declared in a consumed module, you cannot change it here -
+# you must update the module version instead.
+
+# Edit versions.tf or terraform block (if constraint is at ROOT level):
 # Change:
 #   aws = { version = "~> 5.69.0" }
 # To:

--- a/.skills/version-upgrades/SKILL.md
+++ b/.skills/version-upgrades/SKILL.md
@@ -211,7 +211,7 @@ hcptf <org> <workspace> runs $RUN_ID configversion
 > 2. Check the module's documentation/changelog for supported provider versions
 > 3. Fork and modify the module (not recommended for registry modules)
 >
-> Use `terraform init` output to identify where provider version constraints originate.
+> Use `terraform providers` to see the provider dependency tree and identify where constraints originate.
 
 ```hcl
 # In versions.tf or terraform block (ROOT-LEVEL ONLY)
@@ -328,9 +328,17 @@ git checkout main
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-changelog
 
 # IMPORTANT: Check where the provider version constraint comes from
-# Run `terraform init` to see if constraints are in your root config or in modules
+# Run `terraform providers` to see the provider dependency tree
+# This shows which modules declare which provider version constraints
 # If the version is declared in a consumed module, you cannot change it here -
 # you must update the module version instead.
+#
+# Example output:
+# Providers required by configuration:
+# .
+# ├── provider[registry.terraform.io/hashicorp/aws] ~> 6.0
+# └── module.vpc
+#     └── provider[registry.terraform.io/hashicorp/aws] ~> 5.0  ← Module constraint!
 
 # Edit versions.tf or terraform block (if constraint is at ROOT level):
 # Change:


### PR DESCRIPTION
## Summary
This PR fixes a technical inaccuracy in the version upgrades documentation (section 4) regarding provider version updates.

## Problem
The current documentation suggests users can simply update provider versions by editing the `required_providers` block in their root-level `versions.tf` file. However, this doesn't account for the common scenario where provider versions are declared within consumed modules.

## Changes
- Added clear warning that provider version constraints can come from root-level OR module-level sources
- Clarified that module-level provider versions cannot be updated by editing root config
- Provided guidance on how to handle module-declared provider versions (update module version, check module docs, etc.)
- Added note to use `terraform init` output to identify constraint sources
- Updated both the general instructions (section 4) and the detailed scenario example (Scenario 2)

## Why This Matters
Many production setups use registry modules extensively. Users following the current docs would be confused when editing their root `versions.tf` doesn't actually change the provider version because it's controlled by a module they're consuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)