### PR TITLE
fix: assessmentresult list uses correct current-assessment-result endpoint

### DIFF
--- a/command/assessmentresult_list.go
+++ b/command/assessmentresult_list.go
@@ -73,7 +73,7 @@ func (c *AssessmentResultListCommand) Run(args []string) int {
 		return 1
 	}
 
-	apiURL := fmt.Sprintf("%s/api/v2/workspaces/%s/assessment-results", client.GetAddress(), workspace.ID)
+	apiURL := fmt.Sprintf("%s/api/v2/workspaces/%s/current-assessment-result", client.GetAddress(), workspace.ID)
 	req, err := http.NewRequestWithContext(client.Context(), http.MethodGet, apiURL, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error creating request: %s", err))

--- a/command/assessmentresult_list_test.go
+++ b/command/assessmentresult_list_test.go
@@ -145,7 +145,7 @@ func TestAssessmentResultListRunNoResults(t *testing.T) {
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		case "/api/v2/organizations/my-org/workspaces/my-workspace":
 			_, _ = w.Write([]byte(`{"data":{"id":"ws-123","type":"workspaces","attributes":{"name":"my-workspace"}}}`))
-		case "/api/v2/workspaces/ws-123/assessment-results":
+		case "/api/v2/workspaces/ws-123/current-assessment-result":
 			_, _ = w.Write([]byte(`{"data":[]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -173,7 +173,7 @@ func TestAssessmentResultListRunHasResults(t *testing.T) {
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		case "/api/v2/organizations/my-org/workspaces/my-workspace":
 			_, _ = w.Write([]byte(`{"data":{"id":"ws-123","type":"workspaces","attributes":{"name":"my-workspace"}}}`))
-		case "/api/v2/workspaces/ws-123/assessment-results":
+		case "/api/v2/workspaces/ws-123/current-assessment-result":
 			_, _ = w.Write([]byte(`{"data":[{"id":"ar-1","type":"assessment-results","attributes":{"drifted":true,"succeeded":false,"created-at":"2024-01-01T00:00:00Z","error-msg":"Drift detected"},{"id":"ar-2","type":"assessment-results","attributes":{"drifted":false,"succeeded":true,"created-at":"2024-02-01T00:00:00Z"}}]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -203,7 +203,7 @@ func TestAssessmentResultListRunJSONOutput(t *testing.T) {
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		case "/api/v2/organizations/my-org/workspaces/my-workspace":
 			_, _ = w.Write([]byte(`{"data":{"id":"ws-123","type":"workspaces","attributes":{"name":"my-workspace"}}}`))
-		case "/api/v2/workspaces/ws-123/assessment-results":
+		case "/api/v2/workspaces/ws-123/current-assessment-result":
 			_, _ = w.Write([]byte(`{"data":[{"id":"ar-1","type":"assessment-results","attributes":{"drifted":false,"succeeded":true,"created-at":"2024-01-01T00:00:00Z"}}]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -237,7 +237,7 @@ func TestAssessmentResultListRunAPIError(t *testing.T) {
 			_, _ = w.Write([]byte(`{"ok":true}`))
 		case "/api/v2/organizations/my-org/workspaces/my-workspace":
 			_, _ = w.Write([]byte(`{"data":{"id":"ws-123","type":"workspaces","attributes":{"name":"my-workspace"}}}`))
-		case "/api/v2/workspaces/ws-123/assessment-results":
+		case "/api/v2/workspaces/ws-123/current-assessment-result":
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"message":"backend error"}`))
 		default:


### PR DESCRIPTION
The assessmentresult list command was hitting /api/v2/workspaces/<id>/assessment-results which returns 404. The correct endpoint is /api/v2/workspaces/<id>/current-assessment-result as documented in the HCP Terraform API and confirmed via the workspace relationships metadata.

## Changes
- Updated assessmentresult_list.go to use the correct endpoint
- Updated all test cases in assessmentresult_list_test.go to match the new endpoint

## Verification
The fix updates the API endpoint from the incorrect assessment-results to the correct current-assessment-result path. The assessmentresult read command continues to use the correct /api/v2/assessment-results/<id> endpoint unchanged.