### PR TITLE
feat(dotenv, install): add dotenv defaults and justfile recipes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+TFE_ADDRESS=https://app.terraform.io
+TFE_TOKEN=
+
+# hcptf-specific values can be used when they should differ from Terraform CLI.
+# HCPTF_ADDRESS=https://tfe.example.com
+# HCPTF_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,10 @@ TFE_ORG=
 # HCPTF_ADDRESS=https://tfe.example.com
 # HCPTF_TOKEN=
 # HCPTF_ORG=
+
+# Env files are loaded without overriding exported variables.
+# Discovery order:
+# 1. --env-file / HCPTF_ENV_FILE
+# 2. .env in the current directory, then ancestor directories
+# 3. ~/.hcptf.env
+# 4. ~/.config/hcptf/env

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 TFE_ADDRESS=https://app.terraform.io
 TFE_TOKEN=
+TFE_ORG=
 
 # hcptf-specific values can be used when they should differ from Terraform CLI.
 # HCPTF_ADDRESS=https://tfe.example.com
 # HCPTF_TOKEN=
+# HCPTF_ORG=

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ go.work.sum
 Thumbs.db
 
 # Config files with credentials
+.env
 .hcptfrc
 *.tfvars
 *.auto.tfvars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dotenv configuration defaults**: Load HCP Terraform connection settings from explicit `--env-file` / `HCPTF_ENV_FILE`, project `.env` files, and user-level env files without overriding exported environment variables
+- **Default organization environment variables**: Support `TFE_ORG` and `HCPTF_ORG` as default organization sources for commands with `-organization` / `-org` flags
+- **Justfile recipes**: Add `just build`, `just install`, and `just test` shortcuts for common development workflows
+
 ## [0.6.0] - 2026-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ If you've already run `terraform login`, no setup is needed - `hcptf` reads thos
 
 Other authentication methods (checked in order):
 
-1. `TFE_TOKEN` environment variable
-2. `HCPTF_TOKEN` environment variable
-3. `~/.hcptfrc` configuration file (HCL format)
-4. `~/.terraform.d/credentials.tfrc.json`
+1. Exported `TFE_TOKEN` environment variable
+2. Exported `HCPTF_TOKEN` environment variable
+3. Explicit env file via `--env-file` or `HCPTF_ENV_FILE`
+4. Project-local `.env` file
+5. `~/.hcptfrc` configuration file (HCL format)
+6. `~/.terraform.d/credentials.tfrc.json`
 
 See [docs/AUTH_GUIDE.md](docs/AUTH_GUIDE.md) for details on CI/CD setup, multiple TFE instances, and troubleshooting.
 
@@ -75,6 +77,22 @@ export TFE_ADDRESS="https://tfe.example.com"    # Legacy support
 ```
 
 Note: `HCPTF_ADDRESS` takes precedence over `TFE_ADDRESS` for compatibility.
+
+For local workflows, copy `.env.example` to `.env` and keep the real file out of
+version control:
+
+```bash
+cp .env.example .env
+chmod 600 .env
+hcptf whoami
+```
+
+Select a workflow-specific file explicitly when needed:
+
+```bash
+hcptf --env-file .env.tfe-prod whoami
+HCPTF_ENV_FILE=.env.tfe-dev hcptf workspace list -org=my-org
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ export TFE_ADDRESS="https://tfe.example.com"    # Legacy support
 
 Note: `HCPTF_ADDRESS` takes precedence over `TFE_ADDRESS` for compatibility.
 
+Set a default organization for commands that accept `-organization`/`-org`:
+
+```bash
+export TFE_ORG="my-org"
+```
+
 For local workflows, copy `.env.example` to `.env` and keep the real file out of
 version control:
 
@@ -91,7 +97,7 @@ Select a workflow-specific file explicitly when needed:
 
 ```bash
 hcptf --env-file .env.tfe-prod whoami
-HCPTF_ENV_FILE=.env.tfe-dev hcptf workspace list -org=my-org
+HCPTF_ENV_FILE=.env.tfe-dev hcptf workspace list
 ```
 
 ## Usage

--- a/command/agentpool_create.go
+++ b/command/agentpool_create.go
@@ -21,8 +21,8 @@ type AgentPoolCreateCommand struct {
 // Run executes the agent pool create command
 func (c *AgentPoolCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("agentpool create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Agent pool name (required)")
 	flags.BoolVar(&c.organizationScoped, "organization-scoped", false, "Make agent pool organization scoped")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/agentpool_list.go
+++ b/command/agentpool_list.go
@@ -17,8 +17,8 @@ type AgentPoolListCommand struct {
 // Run executes the agent pool list command
 func (c *AgentPoolListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("agentpool list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/assessmentresult_list.go
+++ b/command/assessmentresult_list.go
@@ -36,8 +36,8 @@ type AssessmentResultListResponse struct {
 // Run executes the assessmentresult list command
 func (c *AssessmentResultListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("assessmentresult list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/audittrail_list.go
+++ b/command/audittrail_list.go
@@ -21,8 +21,8 @@ type AuditTrailListCommand struct {
 // Run executes the audit trail list command
 func (c *AuditTrailListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("audittrail list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.since, "since", "", "Return audit events since this date (ISO8601 format: YYYY-MM-DDTHH:MM:SS.SSSZ)")
 	flags.IntVar(&c.pageNumber, "page-number", 1, "Page number")
 	flags.IntVar(&c.pageSize, "page-size", 100, "Number of items per page (max 1000)")

--- a/command/audittrailtoken_create.go
+++ b/command/audittrailtoken_create.go
@@ -19,8 +19,8 @@ type AuditTrailTokenCreateCommand struct {
 // Run executes the audit trail token create command
 func (c *AuditTrailTokenCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("audittrailtoken create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.expiredAt, "expired-at", "", "Token expiration date (ISO8601 format: YYYY-MM-DDTHH:MM:SS.SSSZ)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/audittrailtoken_delete.go
+++ b/command/audittrailtoken_delete.go
@@ -19,8 +19,8 @@ type AuditTrailTokenDeleteCommand struct {
 // Run executes the audit trail token delete command
 func (c *AuditTrailTokenDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("audittrailtoken delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/audittrailtoken_list.go
+++ b/command/audittrailtoken_list.go
@@ -17,8 +17,8 @@ type AuditTrailTokenListCommand struct {
 // Run executes the audit trail token list command
 func (c *AuditTrailTokenListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("audittrailtoken list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/audittrailtoken_read.go
+++ b/command/audittrailtoken_read.go
@@ -17,8 +17,8 @@ type AuditTrailTokenReadCommand struct {
 // Run executes the audit trail token read command
 func (c *AuditTrailTokenReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("audittrailtoken read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/awsoidc_create.go
+++ b/command/awsoidc_create.go
@@ -18,8 +18,8 @@ type AWSoidcCreateCommand struct {
 // Run executes the awsoidc create command
 func (c *AWSoidcCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("awsoidc create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.roleArn, "role-arn", "", "AWS IAM role ARN (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/azureoidc_create.go
+++ b/command/azureoidc_create.go
@@ -20,8 +20,8 @@ type AzureoidcCreateCommand struct {
 // Run executes the azureoidc create command
 func (c *AzureoidcCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("azureoidc create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.clientID, "client-id", "", "Azure application (client) ID (required)")
 	flags.StringVar(&c.subscriptionID, "subscription-id", "", "Azure subscription ID (required)")
 	flags.StringVar(&c.tenantID, "tenant-id", "", "Azure tenant (directory) ID (required)")

--- a/command/changerequest_create.go
+++ b/command/changerequest_create.go
@@ -53,8 +53,8 @@ type BulkActionResponse struct {
 // Run executes the changerequest create command
 func (c *ChangeRequestCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("changerequest create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.subject, "subject", "", "Change request subject (required)")
 	flags.StringVar(&c.message, "message", "", "Change request message (required)")

--- a/command/changerequest_list.go
+++ b/command/changerequest_list.go
@@ -60,8 +60,8 @@ type ChangeRequestListResponse struct {
 // Run executes the changerequest list command
 func (c *ChangeRequestListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("changerequest list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/configversion_create.go
+++ b/command/configversion_create.go
@@ -24,8 +24,8 @@ type ConfigVersionCreateCommand struct {
 // Run executes the configversion create command
 func (c *ConfigVersionCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("configversion create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.BoolVar(&c.autoQueueRuns, "auto-queue-runs", true, "Automatically queue runs when uploaded")
 	flags.BoolVar(&c.speculative, "speculative", false, "Create a speculative configuration version")

--- a/command/configversion_list.go
+++ b/command/configversion_list.go
@@ -21,8 +21,8 @@ type ConfigVersionListCommand struct {
 // Run executes the configversion list command
 func (c *ConfigVersionListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("configversion list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/env_test.go
+++ b/command/env_test.go
@@ -1,0 +1,13 @@
+package command
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/hcptf-cli/internal/config"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv(config.DisableEnvFileVariable, "1")
+	os.Exit(m.Run())
+}

--- a/command/explorer_query.go
+++ b/command/explorer_query.go
@@ -29,8 +29,8 @@ type ExplorerQueryCommand struct {
 // Run executes the explorer query command
 func (c *ExplorerQueryCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("explorer query")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.queryType, "type", "", "Query type: workspaces, tf_versions, providers, modules (required)")
 	flags.StringVar(&c.sort, "sort", "", "Sort field (prefix with - for descending)")
 	flags.StringVar(&c.filter, "filter", "", "Filter conditions")

--- a/command/gcpoidc_create.go
+++ b/command/gcpoidc_create.go
@@ -20,8 +20,8 @@ type GCPoidcCreateCommand struct {
 // Run executes the gcpoidc create command
 func (c *GCPoidcCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("gcpoidc create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.serviceAccountEmail, "service-account-email", "", "GCP service account email (required)")
 	flags.StringVar(&c.workloadProviderName, "workload-provider-name", "", "Workload provider path (required)")
 	flags.StringVar(&c.projectNumber, "project-number", "", "GCP project number (required)")

--- a/command/githubapp_list.go
+++ b/command/githubapp_list.go
@@ -16,8 +16,8 @@ type GitHubAppListCommand struct {
 
 func (c *GitHubAppListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("githubapp list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/gpgkey_create.go
+++ b/command/gpgkey_create.go
@@ -98,8 +98,8 @@ func (c *GPGKeyCreateCommand) Run(args []string) int {
 			"action":   "create",
 			"resource": "gpgkey",
 			"options": map[string]interface{}{
-				"namespace":    options.Namespace,
-				"ascii_armor":  "(redacted)",
+				"namespace":   options.Namespace,
+				"ascii_armor": "(redacted)",
 			},
 		})
 		return 0

--- a/command/hyok_create.go
+++ b/command/hyok_create.go
@@ -25,7 +25,7 @@ type HYOKCreateCommand struct {
 // Run executes the HYOK create command
 func (c *HYOKCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("hyok create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
 	flags.StringVar(&c.name, "name", "", "HYOK configuration name (required)")
 	flags.StringVar(&c.kekID, "kek-id", "", "Key Encryption Key ID from your KMS (required)")
 	flags.StringVar(&c.agentPoolID, "agent-pool-id", "", "Agent pool ID (required)")

--- a/command/hyok_list.go
+++ b/command/hyok_list.go
@@ -17,7 +17,7 @@ type HYOKListCommand struct {
 // Run executes the HYOK list command
 func (c *HYOKListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("hyok list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/meta.go
+++ b/command/meta.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/hashicorp/hcptf-cli/internal/client"
 	"github.com/hashicorp/hcptf-cli/internal/config"
-	"github.com/hashicorp/hcptf-cli/internal/validate"
 	"github.com/hashicorp/hcptf-cli/internal/output"
+	"github.com/hashicorp/hcptf-cli/internal/validate"
 	"github.com/mitchellh/cli"
 )
 
@@ -103,6 +103,15 @@ func (m *Meta) Config() (*config.Config, error) {
 
 	m.config, m.configErr = config.Load()
 	return m.config, m.configErr
+}
+
+// DefaultOrganization returns the configured organization, if one exists.
+func (m *Meta) DefaultOrganization() string {
+	cfg, err := m.Config()
+	if err != nil {
+		return ""
+	}
+	return cfg.DefaultOrganization
 }
 
 // FlagSet returns a FlagSet with common flags

--- a/command/nocode_create.go
+++ b/command/nocode_create.go
@@ -18,8 +18,8 @@ type NoCodeCreateCommand struct {
 
 func (c *NoCodeCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("nocode create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.payload, "payload", "", "JSON payload for the create request")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/nocode_list.go
+++ b/command/nocode_list.go
@@ -16,8 +16,8 @@ type NoCodeListCommand struct {
 
 func (c *NoCodeListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("nocode list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/nocode_read.go
+++ b/command/nocode_read.go
@@ -16,8 +16,8 @@ type NoCodeReadCommand struct {
 
 func (c *NoCodeReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("nocode read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/nocode_update.go
+++ b/command/nocode_update.go
@@ -18,8 +18,8 @@ type NoCodeUpdateCommand struct {
 
 func (c *NoCodeUpdateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("nocode update")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.payload, "payload", "", "JSON payload for the update request")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/notification_create.go
+++ b/command/notification_create.go
@@ -25,8 +25,8 @@ type NotificationCreateCommand struct {
 // Run executes the notification create command
 func (c *NotificationCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("notification create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.name, "name", "", "Notification configuration name (required)")
 	flags.StringVar(&c.destinationType, "destination-type", "", "Destination type: email, slack, generic, microsoft-teams (required)")
@@ -109,18 +109,18 @@ func (c *NotificationCreateCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error parsing JSON input: %s", err))
 			return 1
 		}
-		} else {
-			var destType tfe.NotificationDestinationType
-			switch c.destinationType {
-			case "email":
-				destType = tfe.NotificationDestinationTypeEmail
-			case "slack":
-				destType = tfe.NotificationDestinationTypeSlack
-			case "generic":
-				destType = tfe.NotificationDestinationTypeGeneric
-			default:
-				destType = tfe.NotificationDestinationTypeMicrosoftTeams
-			}
+	} else {
+		var destType tfe.NotificationDestinationType
+		switch c.destinationType {
+		case "email":
+			destType = tfe.NotificationDestinationTypeEmail
+		case "slack":
+			destType = tfe.NotificationDestinationTypeSlack
+		case "generic":
+			destType = tfe.NotificationDestinationTypeGeneric
+		default:
+			destType = tfe.NotificationDestinationTypeMicrosoftTeams
+		}
 		options = tfe.NotificationConfigurationCreateOptions{
 			Name:            tfe.String(c.name),
 			DestinationType: &destType,

--- a/command/notification_list.go
+++ b/command/notification_list.go
@@ -18,8 +18,8 @@ type NotificationListCommand struct {
 // Run executes the notification list command
 func (c *NotificationListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("notification list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/oauthclient_create.go
+++ b/command/oauthclient_create.go
@@ -27,8 +27,8 @@ type OAuthClientCreateCommand struct {
 // Run executes the oauthclient create command
 func (c *OAuthClientCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("oauthclient create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.serviceProvider, "service-provider", "", "VCS provider: github, github_enterprise, gitlab_hosted, gitlab_community_edition, gitlab_enterprise_edition, ado_server (required)")
 	flags.StringVar(&c.name, "name", "", "Display name for the OAuth client")
 	flags.StringVar(&c.httpURL, "http-url", "", "VCS provider HTTP URL (required)")

--- a/command/oauthclient_list.go
+++ b/command/oauthclient_list.go
@@ -24,8 +24,8 @@ type OAuthClientListCommand struct {
 // Run executes the oauthclient list command
 func (c *OAuthClientListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("oauthclient list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/oauthtoken_list.go
+++ b/command/oauthtoken_list.go
@@ -24,8 +24,8 @@ type OAuthTokenListCommand struct {
 // Run executes the oauthtoken list command
 func (c *OAuthTokenListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("oauthtoken list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/organizationmembership_create.go
+++ b/command/organizationmembership_create.go
@@ -19,8 +19,8 @@ type OrganizationMembershipCreateCommand struct {
 // Run executes the organization membership create command
 func (c *OrganizationMembershipCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationmembership create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.email, "email", "", "Email address of user to invite (required)")
 	flags.StringVar(&c.teamIDs, "team-ids", "", "Comma-separated list of team IDs (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/organizationmembership_list.go
+++ b/command/organizationmembership_list.go
@@ -19,8 +19,8 @@ type OrganizationMembershipListCommand struct {
 // Run executes the organization membership list command
 func (c *OrganizationMembershipListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationmembership list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.status, "status", "", "Filter by status (invited, active)")
 	flags.StringVar(&c.email, "email", "", "Filter by email address")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/organizationtag_create.go
+++ b/command/organizationtag_create.go
@@ -20,8 +20,8 @@ type OrganizationTagCreateCommand struct {
 // Run executes the organizationtag create command.
 func (c *OrganizationTagCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtag create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Tag name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/organizationtag_delete.go
+++ b/command/organizationtag_delete.go
@@ -18,8 +18,8 @@ type OrganizationTagDeleteCommand struct {
 // Run executes the organizationtag delete command
 func (c *OrganizationTagDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtag delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.id, "id", "", "Tag ID (required)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
 

--- a/command/organizationtag_list.go
+++ b/command/organizationtag_list.go
@@ -17,8 +17,8 @@ type OrganizationTagListCommand struct {
 // Run executes the organizationtag list command
 func (c *OrganizationTagListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtag list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/organizationtoken_create.go
+++ b/command/organizationtoken_create.go
@@ -19,8 +19,8 @@ type OrganizationTokenCreateCommand struct {
 // Run executes the organization token create command
 func (c *OrganizationTokenCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtoken create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.expiredAt, "expired-at", "", "Expiration date in ISO 8601 format (e.g., 2024-12-31T23:59:59Z)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/organizationtoken_delete.go
+++ b/command/organizationtoken_delete.go
@@ -15,8 +15,8 @@ type OrganizationTokenDeleteCommand struct {
 // Run executes the organization token delete command
 func (c *OrganizationTokenDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtoken delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/organizationtoken_list.go
+++ b/command/organizationtoken_list.go
@@ -15,8 +15,8 @@ type OrganizationTokenListCommand struct {
 // Run executes the organization token list command
 func (c *OrganizationTokenListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtoken list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/organizationtoken_read.go
+++ b/command/organizationtoken_read.go
@@ -15,8 +15,8 @@ type OrganizationTokenReadCommand struct {
 // Run executes the organization token read command
 func (c *OrganizationTokenReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("organizationtoken read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/policy_create.go
+++ b/command/policy_create.go
@@ -29,8 +29,8 @@ type policyCreateJSONInput struct {
 // Run executes the policy create command
 func (c *PolicyCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("policy create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Policy name (required)")
 	flags.StringVar(&c.description, "description", "", "Policy description")
 	flags.StringVar(&c.enforce, "enforce", "advisory", "Enforcement level: advisory, soft-mandatory, or hard-mandatory")

--- a/command/policy_list.go
+++ b/command/policy_list.go
@@ -19,8 +19,8 @@ type PolicyListCommand struct {
 // Run executes the policy list command
 func (c *PolicyListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("policy list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/policyset_create.go
+++ b/command/policyset_create.go
@@ -25,8 +25,8 @@ type PolicySetCreateCommand struct {
 // Run executes the policy set create command
 func (c *PolicySetCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("policyset create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Policy set name (required)")
 	flags.StringVar(&c.description, "description", "", "Policy set description")
 	flags.BoolVar(&c.global, "global", false, "Apply to all workspaces")

--- a/command/policyset_list.go
+++ b/command/policyset_list.go
@@ -22,8 +22,8 @@ type PolicySetListCommand struct {
 // Run executes the policy set list command
 func (c *PolicySetListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("policyset list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.search, "search", "", "Search policy set names by substring")
 	flags.StringVar(&c.kind, "kind", "", "Filter by policy set kind: sentinel or opa")
 	flags.StringVar(&c.include, "include", "", "Include related resources (comma-separated)")

--- a/command/project_create.go
+++ b/command/project_create.go
@@ -19,8 +19,8 @@ type ProjectCreateCommand struct {
 // Run executes the project create command
 func (c *ProjectCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("project create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Project name (required)")
 	flags.StringVar(&c.description, "description", "", "Project description")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/project_list.go
+++ b/command/project_list.go
@@ -19,8 +19,8 @@ type ProjectListCommand struct {
 // Run executes the project list command
 func (c *ProjectListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("project list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/queryrun_list.go
+++ b/command/queryrun_list.go
@@ -26,8 +26,8 @@ type QueryRunListCommand struct {
 // Run executes the query run list command
 func (c *QueryRunListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("queryrun list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.status, "status", "", "Filter by run status (comma-separated)")
 	flags.StringVar(&c.operation, "operation", "", "Filter by operation type (comma-separated)")
 	flags.StringVar(&c.source, "source", "", "Filter by run source (comma-separated)")

--- a/command/queryworkspace_list.go
+++ b/command/queryworkspace_list.go
@@ -21,8 +21,8 @@ type QueryWorkspaceListCommand struct {
 // Run executes the query workspace list command
 func (c *QueryWorkspaceListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("queryworkspace list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.search, "search", "", "Search query for workspace name")
 	flags.StringVar(&c.tags, "tags", "", "Filter by tags (comma-separated)")
 	flags.StringVar(&c.excludeTags, "exclude-tags", "", "Exclude workspaces with tags (comma-separated)")

--- a/command/registrymodule_create.go
+++ b/command/registrymodule_create.go
@@ -22,8 +22,8 @@ type RegistryModuleCreateCommand struct {
 // Run executes the registry module create command
 func (c *RegistryModuleCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registrymodule create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Module name (required)")
 	flags.StringVar(&c.provider, "provider", "", "Provider name (required)")
 	flags.StringVar(&c.registryName, "registry-name", "private", "Registry name: public or private (default: private)")

--- a/command/registrymodule_create_version.go
+++ b/command/registrymodule_create_version.go
@@ -24,8 +24,8 @@ type RegistryModuleCreateVersionCommand struct {
 // Run executes the registry module create-version command
 func (c *RegistryModuleCreateVersionCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registrymodule create-version")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Module name (required)")
 	flags.StringVar(&c.provider, "provider", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")

--- a/command/registrymodule_delete.go
+++ b/command/registrymodule_delete.go
@@ -19,8 +19,8 @@ type RegistryModuleDeleteCommand struct {
 // Run executes the registry module delete command
 func (c *RegistryModuleDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registrymodule delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Module name (required)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
 	flags.BoolVar(&c.force, "f", false, "Shorthand for -force")

--- a/command/registrymodule_delete_version.go
+++ b/command/registrymodule_delete_version.go
@@ -22,8 +22,8 @@ type RegistryModuleDeleteVersionCommand struct {
 // Run executes the registry module delete-version command
 func (c *RegistryModuleDeleteVersionCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registrymodule delete-version")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Module name (required)")
 	flags.StringVar(&c.provider, "provider", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")

--- a/command/registrymodule_list.go
+++ b/command/registrymodule_list.go
@@ -18,8 +18,8 @@ type RegistryModuleListCommand struct {
 // Run executes the registry module list command
 func (c *RegistryModuleListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registrymodule list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/registrymodule_read.go
+++ b/command/registrymodule_read.go
@@ -22,8 +22,8 @@ type RegistryModuleReadCommand struct {
 // Run executes the registry module read command
 func (c *RegistryModuleReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registrymodule read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Module name (required)")
 	flags.StringVar(&c.provider, "provider", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")

--- a/command/registryprovider_create.go
+++ b/command/registryprovider_create.go
@@ -21,8 +21,8 @@ type RegistryProviderCreateCommand struct {
 // Run executes the registry provider create command
 func (c *RegistryProviderCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryprovider create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.registryName, "registry-name", "private", "Registry name: public or private (default: private)")

--- a/command/registryprovider_delete.go
+++ b/command/registryprovider_delete.go
@@ -22,8 +22,8 @@ type RegistryProviderDeleteCommand struct {
 // Run executes the registry provider delete command
 func (c *RegistryProviderDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryprovider delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.registryName, "registry-name", "private", "Registry name: public or private (default: private)")

--- a/command/registryprovider_list.go
+++ b/command/registryprovider_list.go
@@ -18,8 +18,8 @@ type RegistryProviderListCommand struct {
 // Run executes the registry provider list command
 func (c *RegistryProviderListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryprovider list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/registryprovider_read.go
+++ b/command/registryprovider_read.go
@@ -21,8 +21,8 @@ type RegistryProviderReadCommand struct {
 // Run executes the registry provider read command
 func (c *RegistryProviderReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryprovider read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.registryName, "registry-name", "private", "Registry name: public or private (default: private)")

--- a/command/registryproviderplatform_create.go
+++ b/command/registryproviderplatform_create.go
@@ -23,8 +23,8 @@ type RegistryProviderPlatformCreateCommand struct {
 // Run executes the registry provider platform create command
 func (c *RegistryProviderPlatformCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryproviderplatform create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.version, "version", "", "Version string (required)")

--- a/command/registryproviderplatform_delete.go
+++ b/command/registryproviderplatform_delete.go
@@ -29,8 +29,8 @@ type RegistryProviderPlatformDeleteCommand struct {
 // Run executes the registry provider platform delete command
 func (c *RegistryProviderPlatformDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryproviderplatform delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.version, "version", "", "Version string (required)")

--- a/command/registryproviderplatform_read.go
+++ b/command/registryproviderplatform_read.go
@@ -21,8 +21,8 @@ type RegistryProviderPlatformReadCommand struct {
 // Run executes the registry provider platform read command
 func (c *RegistryProviderPlatformReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryproviderplatform read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.version, "version", "", "Version string (required)")

--- a/command/registryproviderversion_create.go
+++ b/command/registryproviderversion_create.go
@@ -23,8 +23,8 @@ type RegistryProviderVersionCreateCommand struct {
 // Run executes the registry provider version create command
 func (c *RegistryProviderVersionCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryproviderversion create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.version, "version", "", "Version string, e.g., 1.0.0 (required)")

--- a/command/registryproviderversion_delete.go
+++ b/command/registryproviderversion_delete.go
@@ -22,8 +22,8 @@ type RegistryProviderVersionDeleteCommand struct {
 // Run executes the registry provider version delete command
 func (c *RegistryProviderVersionDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryproviderversion delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.version, "version", "", "Version string (required)")

--- a/command/registryproviderversion_read.go
+++ b/command/registryproviderversion_read.go
@@ -19,8 +19,8 @@ type RegistryProviderVersionReadCommand struct {
 // Run executes the registry provider version read command
 func (c *RegistryProviderVersionReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("registryproviderversion read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Provider name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Namespace (defaults to organization)")
 	flags.StringVar(&c.version, "version", "", "Version string (required)")

--- a/command/reservedtagkey_create.go
+++ b/command/reservedtagkey_create.go
@@ -21,8 +21,8 @@ type ReservedTagKeyCreateCommand struct {
 // Run executes the reservedtagkey create command
 func (c *ReservedTagKeyCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("reservedtagkey create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.key, "key", "", "Tag key to reserve (required)")
 	flags.BoolVar(&c.disableOverrides, "disable-overrides", false, "Disable overriding inherited tags at workspace level")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/reservedtagkey_list.go
+++ b/command/reservedtagkey_list.go
@@ -17,8 +17,8 @@ type ReservedTagKeyListCommand struct {
 // Run executes the reservedtagkey list command
 func (c *ReservedTagKeyListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("reservedtagkey list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/run_create.go
+++ b/command/run_create.go
@@ -24,8 +24,8 @@ type RunCreateCommand struct {
 // Run executes the run create command
 func (c *RunCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("run create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (alias)")
 	flags.StringVar(&c.message, "message", "", "Run message")

--- a/command/run_list.go
+++ b/command/run_list.go
@@ -29,8 +29,8 @@ type RunListCommand struct {
 // Run executes the run list command
 func (c *RunListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("run list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (alias)")
 	flags.StringVar(&c.user, "user", "", "Filter runs by VCS username")

--- a/command/run_list_org.go
+++ b/command/run_list_org.go
@@ -30,8 +30,8 @@ type RunListOrgCommand struct {
 // Run executes the run list-org command.
 func (c *RunListOrgCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("run list-org")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.user, "user", "", "Filter by VCS username")
 	flags.StringVar(&c.commit, "commit", "", "Filter by commit SHA")
 	flags.StringVar(&c.search, "search", "", "Search runs by username, commit, run ID, or message")

--- a/command/runtask_attach.go
+++ b/command/runtask_attach.go
@@ -21,8 +21,8 @@ type RunTaskAttachCommand struct {
 // Run executes the run task attach command
 func (c *RunTaskAttachCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("runtask attach")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.runTaskID, "runtask-id", "", "Run task ID (required)")
 	flags.StringVar(&c.enforcementLevel, "enforcement-level", "advisory", "Enforcement level: advisory or mandatory (default: advisory)")

--- a/command/runtask_create.go
+++ b/command/runtask_create.go
@@ -25,8 +25,8 @@ type RunTaskCreateCommand struct {
 // Run executes the run task create command
 func (c *RunTaskCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("runtask create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Run task name (required)")
 	flags.StringVar(&c.url, "url", "", "Run task URL (required)")
 	flags.StringVar(&c.hmacKey, "hmac-key", "", "HMAC key for request authentication (optional)")

--- a/command/runtask_detach.go
+++ b/command/runtask_detach.go
@@ -17,8 +17,8 @@ type RunTaskDetachCommand struct {
 // Run executes the run task detach command
 func (c *RunTaskDetachCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("runtask detach")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.workspaceRunTaskID, "workspace-runtask-id", "", "Workspace run task ID (required)")
 	flags.BoolVar(&c.force, "force", false, "Force detach without confirmation")

--- a/command/runtask_list.go
+++ b/command/runtask_list.go
@@ -17,8 +17,8 @@ type RunTaskListCommand struct {
 // Run executes the run task list command
 func (c *RunTaskListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("runtask list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/runtrigger_create.go
+++ b/command/runtrigger_create.go
@@ -22,8 +22,8 @@ type RunTriggerCreateCommand struct {
 // Run executes the run trigger create command
 func (c *RunTriggerCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("runtrigger create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Target workspace name (required)")
 	flags.StringVar(&c.sourceWorkspace, "source-workspace", "", "Source workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/runtrigger_list.go
+++ b/command/runtrigger_list.go
@@ -22,8 +22,8 @@ type RunTriggerListCommand struct {
 // Run executes the run trigger list command
 func (c *RunTriggerListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("runtrigger list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.triggerType, "type", "inbound", "Run trigger type: inbound or outbound (default: inbound)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/sshkey_create.go
+++ b/command/sshkey_create.go
@@ -21,8 +21,8 @@ type SSHKeyCreateCommand struct {
 // Run executes the SSH key create command
 func (c *SSHKeyCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("sshkey create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "SSH key name (required)")
 	flags.StringVar(&c.value, "value", "", "SSH private key content (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/sshkey_list.go
+++ b/command/sshkey_list.go
@@ -17,8 +17,8 @@ type SSHKeyListCommand struct {
 // Run executes the SSH key list command
 func (c *SSHKeyListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("sshkey list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/stack_list.go
+++ b/command/stack_list.go
@@ -18,8 +18,8 @@ type StackListCommand struct {
 // Run executes the stack list command
 func (c *StackListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("stack list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.project, "project", "", "Filter by project ID")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/state_download.go
+++ b/command/state_download.go
@@ -26,7 +26,7 @@ type StateDownloadCommand struct {
 // Run executes the state download command
 func (c *StateDownloadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("state download")
-	flags.StringVar(&c.organization, "org", "", "Organization name")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name")
 	flags.StringVar(&c.stateVersionID, "id", "", "State version ID (optional, defaults to current)")
 	flags.StringVar(&c.outputFile, "output", "", "Output file path (required)")

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -18,8 +18,8 @@ type StateListCommand struct {
 // Run executes the state list command
 func (c *StateListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("state list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/state_outputs.go
+++ b/command/state_outputs.go
@@ -16,8 +16,8 @@ type StateOutputsCommand struct {
 // Run executes the state outputs command
 func (c *StateOutputsCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("state outputs")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/team_add_member.go
+++ b/command/team_add_member.go
@@ -18,8 +18,8 @@ type TeamAddMemberCommand struct {
 // Run executes the team add-member command
 func (c *TeamAddMemberCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("team add-member")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.teamName, "team", "", "Team name (required)")
 	flags.StringVar(&c.username, "username", "", "Username to add (required)")
 

--- a/command/team_create.go
+++ b/command/team_create.go
@@ -19,8 +19,8 @@ type TeamCreateCommand struct {
 // Run executes the team create command
 func (c *TeamCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("team create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Team name (required)")
 	flags.StringVar(&c.visibility, "visibility", "secret", "Team visibility: secret or organization (default: secret)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/team_delete.go
+++ b/command/team_delete.go
@@ -16,8 +16,8 @@ type TeamDeleteCommand struct {
 // Run executes the team delete command
 func (c *TeamDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("team delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Team name (required)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
 

--- a/command/team_list.go
+++ b/command/team_list.go
@@ -19,8 +19,8 @@ type TeamListCommand struct {
 // Run executes the team list command
 func (c *TeamListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("team list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/team_remove_member.go
+++ b/command/team_remove_member.go
@@ -18,8 +18,8 @@ type TeamRemoveMemberCommand struct {
 // Run executes the team remove-member command
 func (c *TeamRemoveMemberCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("team remove-member")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.teamName, "team", "", "Team name (required)")
 	flags.StringVar(&c.username, "username", "", "Username to remove (required)")
 

--- a/command/team_show.go
+++ b/command/team_show.go
@@ -19,8 +19,8 @@ type TeamShowCommand struct {
 // Run executes the team show command
 func (c *TeamShowCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("team show")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Team name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/teamtoken_list.go
+++ b/command/teamtoken_list.go
@@ -15,8 +15,8 @@ type TeamTokenListCommand struct {
 // Run executes the team token list command
 func (c *TeamTokenListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("teamtoken list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 
 	if err := flags.Parse(args); err != nil {

--- a/command/variable_create.go
+++ b/command/variable_create.go
@@ -27,8 +27,8 @@ type VariableCreateCommand struct {
 // Run executes the variable create command
 func (c *VariableCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("variable create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.key, "key", "", "Variable key (required)")
 	flags.StringVar(&c.value, "value", "", "Variable value (required)")

--- a/command/variable_delete.go
+++ b/command/variable_delete.go
@@ -21,8 +21,8 @@ type VariableDeleteCommand struct {
 // Run executes the variable delete command
 func (c *VariableDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("variable delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.id, "id", "", "Variable ID (required)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
@@ -106,10 +106,10 @@ func (c *VariableDeleteCommand) Run(args []string) int {
 	if c.Meta.DryRun {
 		formatter := c.Meta.NewFormatter("json")
 		formatter.JSON(map[string]interface{}{
-			"action":   "delete",
-			"resource": "variable",
-			"name":     c.id,
-			"workspace": c.workspace,
+			"action":       "delete",
+			"resource":     "variable",
+			"name":         c.id,
+			"workspace":    c.workspace,
 			"organization": c.organization,
 		})
 		return 0

--- a/command/variable_list.go
+++ b/command/variable_list.go
@@ -18,8 +18,8 @@ type VariableListCommand struct {
 // Run executes the variable list command
 func (c *VariableListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("variable list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/variable_update.go
+++ b/command/variable_update.go
@@ -27,8 +27,8 @@ type VariableUpdateCommand struct {
 // Run executes the variable update command
 func (c *VariableUpdateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("variable update")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name (required)")
 	flags.StringVar(&c.id, "id", "", "Variable ID (required)")
 	flags.StringVar(&c.key, "key", "", "Variable key")

--- a/command/variableset_create.go
+++ b/command/variableset_create.go
@@ -22,8 +22,8 @@ type VariableSetCreateCommand struct {
 // Run executes the variable set create command
 func (c *VariableSetCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("variableset create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Variable set name (required)")
 	flags.StringVar(&c.description, "description", "", "Variable set description")
 	flags.BoolVar(&c.global, "global", false, "Apply to all workspaces in the organization")

--- a/command/variableset_list.go
+++ b/command/variableset_list.go
@@ -21,8 +21,8 @@ type VariableSetListCommand struct {
 // Run executes the variable set list command
 func (c *VariableSetListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("variableset list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.query, "query", "", "Filter variable sets by name")
 	flags.StringVar(&c.include, "include", "", "Comma-separated related resources to include")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/variableset_variable_delete.go
+++ b/command/variableset_variable_delete.go
@@ -67,10 +67,10 @@ func (c *VariableSetVariableDeleteCommand) Run(args []string) int {
 	if c.Meta.DryRun {
 		formatter := c.Meta.NewFormatter("json")
 		formatter.JSON(map[string]interface{}{
-			"action":          "delete",
-			"resource":        "variableset-variable",
-			"variableset_id":  c.variableSetID,
-			"variable_id":     c.variableID,
+			"action":         "delete",
+			"resource":       "variableset-variable",
+			"variableset_id": c.variableSetID,
+			"variable_id":    c.variableID,
 		})
 		return 0
 	}

--- a/command/vaultoidc_create.go
+++ b/command/vaultoidc_create.go
@@ -22,8 +22,8 @@ type VaultoidcCreateCommand struct {
 // Run executes the vaultoidc create command
 func (c *VaultoidcCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("vaultoidc create")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.address, "address", "", "Vault instance address (required)")
 	flags.StringVar(&c.roleName, "role", "", "Vault JWT auth role name (required)")
 	flags.StringVar(&c.namespace, "namespace", "", "Vault namespace (required)")

--- a/command/vcsevent_list.go
+++ b/command/vcsevent_list.go
@@ -68,8 +68,8 @@ type VCSEventListResponse struct {
 // Run executes the vcsevent list command
 func (c *VCSEventListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("vcsevent list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 	flags.StringVar(&c.from, "from", "", "Start time (RFC3339 format in UTC, e.g., 2021-02-02T14:09:00Z)")
 	flags.StringVar(&c.to, "to", "", "End time (RFC3339 format in UTC, e.g., 2021-02-12T14:09:59Z)")

--- a/command/workspace_create.go
+++ b/command/workspace_create.go
@@ -69,8 +69,8 @@ func (c *WorkspaceCreateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace create")
 
 	// Required
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 
 	// Basic settings

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -19,8 +19,8 @@ type WorkspaceDeleteCommand struct {
 // Run executes the workspace delete command
 func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace delete")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 	flags.BoolVar(&c.force, "force", false, "Force delete without confirmation")
 

--- a/command/workspace_force_unlock.go
+++ b/command/workspace_force_unlock.go
@@ -26,8 +26,8 @@ type WorkspaceForceUnlockCommand struct {
 // Run executes the workspace force-unlock command.
 func (c *WorkspaceForceUnlockCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace force-unlock")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -26,8 +26,8 @@ type WorkspaceListCommand struct {
 // Run executes the workspace list command
 func (c *WorkspaceListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace list")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.search, "search", "", "Search workspace names by substring")
 	flags.StringVar(&c.tags, "tags", "", "Filter by tag names (comma-separated)")
 	flags.StringVar(&c.excludeTags, "exclude-tags", "", "Exclude workspaces with these tags (comma-separated)")

--- a/command/workspace_list_test.go
+++ b/command/workspace_list_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/hcptf-cli/internal/config"
 	"github.com/mitchellh/cli"
 )
 
@@ -64,6 +65,24 @@ func TestWorkspaceListCommandHandlesAPIError(t *testing.T) {
 
 	if out := ui.ErrorWriter.String(); !strings.Contains(out, "boom") {
 		t.Fatalf("expected error output, got %q", out)
+	}
+}
+
+func TestWorkspaceListCommandUsesDefaultOrganization(t *testing.T) {
+	ui := cli.NewMockUi()
+	svc := &mockWorkspaceService{
+		response: &tfe.WorkspaceList{Items: []*tfe.Workspace{}},
+	}
+	cmd := newWorkspaceListCommand(ui, svc)
+	cmd.Meta.config = &config.Config{DefaultOrganization: "default-org"}
+
+	code := cmd.Run(nil)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	if svc.lastOrg != "default-org" {
+		t.Fatalf("expected organization default-org, got %s", svc.lastOrg)
 	}
 }
 

--- a/command/workspace_lock.go
+++ b/command/workspace_lock.go
@@ -27,8 +27,8 @@ type WorkspaceLockCommand struct {
 // Run executes the workspace lock command.
 func (c *WorkspaceLockCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace lock")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.reason, "reason", "", "Reason for locking the workspace")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/workspace_read.go
+++ b/command/workspace_read.go
@@ -26,8 +26,8 @@ type workspaceReaderWithOptions interface {
 // Run executes the workspace read command
 func (c *WorkspaceReadCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace read")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.include, "include", "", "Comma-separated related resources to include (e.g. project,current_run)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")

--- a/command/workspace_unlock.go
+++ b/command/workspace_unlock.go
@@ -26,8 +26,8 @@ type WorkspaceUnlockCommand struct {
 // Run executes the workspace unlock command.
 func (c *WorkspaceUnlockCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace unlock")
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/workspace_update.go
+++ b/command/workspace_update.go
@@ -65,8 +65,8 @@ func (c *WorkspaceUpdateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspace update")
 
 	// Required
-	flags.StringVar(&c.organization, "organization", "", "Organization name (required)")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name (required)")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.name, "name", "", "Workspace name (required)")
 
 	// Basic settings

--- a/command/workspaceresource_list.go
+++ b/command/workspaceresource_list.go
@@ -20,8 +20,8 @@ type WorkspaceResourceListCommand struct {
 func (c *WorkspaceResourceListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspaceresource list")
 	flags.StringVar(&c.workspaceID, "workspace-id", "", "Workspace ID")
-	flags.StringVar(&c.organization, "organization", "", "Organization name")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/command/workspacetag_list.go
+++ b/command/workspacetag_list.go
@@ -21,8 +21,8 @@ func (c *WorkspaceTagListCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("workspacetag list")
 	flags.StringVar(&c.workspaceID, "workspace-id", "", "Workspace ID")
 	flags.StringVar(&c.workspaceID, "id", "", "Workspace ID (alias)")
-	flags.StringVar(&c.organization, "organization", "", "Organization name")
-	flags.StringVar(&c.organization, "org", "", "Organization name (alias)")
+	flags.StringVar(&c.organization, "organization", c.Meta.DefaultOrganization(), "Organization name")
+	flags.StringVar(&c.organization, "org", c.Meta.DefaultOrganization(), "Organization name (alias)")
 	flags.StringVar(&c.workspace, "workspace", "", "Workspace name")
 	flags.StringVar(&c.format, "output", "table", "Output format: table or json")
 

--- a/docs/AUTH_GUIDE.md
+++ b/docs/AUTH_GUIDE.md
@@ -62,6 +62,17 @@ chmod 600 .env
 hcptf whoami
 ```
 
+When `HCPTF_ENV_FILE` / `--env-file` is not set, `hcptf` loads existing env
+files in this order:
+
+1. `.env` in the current directory
+2. `.env` in ancestor directories, stopping at your home directory
+3. `~/.hcptf.env`
+4. `~/.config/hcptf/env`
+
+Files are loaded without overriding existing variables, so a project `.env`
+can override `TFE_ORG` while still inheriting `TFE_TOKEN` from `~/.hcptf.env`.
+
 Select an explicit file:
 
 ```bash

--- a/docs/AUTH_GUIDE.md
+++ b/docs/AUTH_GUIDE.md
@@ -43,6 +43,7 @@ Project-local `.env`:
 ```dotenv
 TFE_ADDRESS=https://app.terraform.io
 TFE_TOKEN=your-token
+TFE_ORG=my-org
 ```
 
 Workflow-specific file:
@@ -50,6 +51,7 @@ Workflow-specific file:
 ```dotenv
 HCPTF_ADDRESS=https://tfe.example.com
 HCPTF_TOKEN=your-enterprise-token
+HCPTF_ORG=my-org
 ```
 
 Use the default `.env` automatically:
@@ -64,7 +66,7 @@ Select an explicit file:
 
 ```bash
 hcptf --env-file .env.tfe-prod whoami
-HCPTF_ENV_FILE=.env.tfe-dev hcptf workspace list -org=my-org
+HCPTF_ENV_FILE=.env.tfe-dev hcptf workspace list
 ```
 
 Never commit real env files. Use CI secret stores for pipeline credentials.

--- a/docs/AUTH_GUIDE.md
+++ b/docs/AUTH_GUIDE.md
@@ -16,10 +16,12 @@ The CLI checks for credentials in this order (first match wins):
 
 | Priority | Method | Best for |
 |----------|--------|----------|
-| 1 | `TFE_TOKEN` env var | CI/CD pipelines |
-| 2 | `HCPTF_TOKEN` env var | Separate hcptf credentials |
-| 3 | `~/.hcptfrc` config file | Multiple instances, custom defaults |
-| 4 | `~/.terraform.d/credentials.tfrc.json` | Shared with Terraform CLI |
+| 1 | Exported `TFE_TOKEN` env var | CI/CD pipelines |
+| 2 | Exported `HCPTF_TOKEN` env var | Separate hcptf credentials |
+| 3 | Explicit env file via `--env-file` or `HCPTF_ENV_FILE` | Local workflow switching |
+| 4 | Project-local `.env` file | Local development defaults |
+| 5 | `~/.hcptfrc` config file | Multiple instances, custom defaults |
+| 6 | `~/.terraform.d/credentials.tfrc.json` | Shared with Terraform CLI |
 
 ### Environment Variables
 
@@ -30,6 +32,42 @@ export TFE_TOKEN="your-token"
 # hcptf-specific - use when you want a different token than terraform
 export HCPTF_TOKEN="your-token"
 ```
+
+### Env Files
+
+`hcptf` can load Terraform Enterprise connection settings from a dotenv file.
+Exported environment variables still win over values in any env file.
+
+Project-local `.env`:
+
+```dotenv
+TFE_ADDRESS=https://app.terraform.io
+TFE_TOKEN=your-token
+```
+
+Workflow-specific file:
+
+```dotenv
+HCPTF_ADDRESS=https://tfe.example.com
+HCPTF_TOKEN=your-enterprise-token
+```
+
+Use the default `.env` automatically:
+
+```bash
+cp .env.example .env
+chmod 600 .env
+hcptf whoami
+```
+
+Select an explicit file:
+
+```bash
+hcptf --env-file .env.tfe-prod whoami
+HCPTF_ENV_FILE=.env.tfe-dev hcptf workspace list -org=my-org
+```
+
+Never commit real env files. Use CI secret stores for pipeline credentials.
 
 ### Configuration File
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-tfe v1.103.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/jsonapi v1.5.0
+	github.com/joho/godotenv v1.5.1
 	github.com/mitchellh/cli v1.1.5
 	github.com/olekukonko/tablewriter v1.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,10 @@ func Load() (*Config, error) {
 		}
 	}
 
+	if org := GetDefaultOrganizationEnv(); org != "" {
+		config.DefaultOrganization = org
+	}
+
 	// Also try to load credentials from Terraform CLI credentials file
 	tfCredsPath := GetTerraformCredentialsPath()
 	if _, err := os.Stat(tfCredsPath); err == nil {
@@ -155,6 +159,17 @@ func GetAddress() string {
 		return addr
 	}
 	return "https://app.terraform.io"
+}
+
+// GetDefaultOrganizationEnv returns the organization configured by environment.
+func GetDefaultOrganizationEnv() string {
+	if org := os.Getenv("TFE_ORG"); org != "" {
+		return org
+	}
+	if org := os.Getenv("HCPTF_ORG"); org != "" {
+		return org
+	}
+	return ""
 }
 
 // GetConfigPath returns the path to the configuration file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,10 @@ type TerraformCredential struct {
 
 // Load loads the configuration from the default location or environment
 func Load() (*Config, error) {
+	if err := LoadDotEnv(); err != nil {
+		return nil, err
+	}
+
 	configPath := GetConfigPath()
 
 	var config Config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,6 +208,71 @@ func TestLoadDotEnvDoesNotOverrideExistingEnvironment(t *testing.T) {
 	}
 }
 
+func TestLoadDotEnvLoadsAncestorFile(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	home := t.TempDir()
+	root := filepath.Join(home, "project")
+	nested := filepath.Join(root, "lab", "b194")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("failed to create nested directory: %v", err)
+	}
+	chdir(t, nested)
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(root, ".env"), "TFE_TOKEN=ancestor-token\n")
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+
+	if got := os.Getenv("TFE_TOKEN"); got != "ancestor-token" {
+		t.Fatalf("expected TFE_TOKEN from ancestor .env, got %q", got)
+	}
+}
+
+func TestLoadDotEnvLoadsUserDefaults(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	home := t.TempDir()
+	work := filepath.Join(home, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatalf("failed to create work directory: %v", err)
+	}
+	chdir(t, work)
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(home, ".hcptf.env"), "TFE_TOKEN=user-token\n")
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+
+	if got := os.Getenv("TFE_TOKEN"); got != "user-token" {
+		t.Fatalf("expected TFE_TOKEN from user defaults, got %q", got)
+	}
+}
+
+func TestLoadDotEnvProjectFileWinsOverUserDefaults(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN", "TFE_ORG")
+	home := t.TempDir()
+	project := filepath.Join(home, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("failed to create project directory: %v", err)
+	}
+	chdir(t, project)
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(home, ".hcptf.env"), "TFE_TOKEN=user-token\nTFE_ORG=user-org\n")
+	writeFile(t, filepath.Join(project, ".env"), "TFE_ORG=project-org\n")
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+
+	if got := os.Getenv("TFE_TOKEN"); got != "user-token" {
+		t.Fatalf("expected TFE_TOKEN from user defaults, got %q", got)
+	}
+	if got := os.Getenv("TFE_ORG"); got != "project-org" {
+		t.Fatalf("expected project TFE_ORG to win, got %q", got)
+	}
+}
+
 func TestLoadDotEnvExplicitFileTakesPrecedenceOverDefaultFile(t *testing.T) {
 	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
 	dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,7 +64,9 @@ func unsetEnv(t *testing.T, keys ...string) {
 }
 
 func TestLoadMergesConfigAndTerraformCredentials(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_ORG", "HCPTF_ORG")
 	home := t.TempDir()
+	chdir(t, t.TempDir())
 	t.Setenv("HOME", home)
 
 	configContent := `
@@ -110,7 +112,9 @@ output_format = "json"
 }
 
 func TestLoadDefaultsWhenConfigMissing(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_ORG", "HCPTF_ORG")
 	home := t.TempDir()
+	chdir(t, t.TempDir())
 	t.Setenv("HOME", home)
 
 	cfg, err := Load()
@@ -124,6 +128,45 @@ func TestLoadDefaultsWhenConfigMissing(t *testing.T) {
 
 	if len(cfg.Credentials) != 0 {
 		t.Fatalf("expected no credentials, got %d", len(cfg.Credentials))
+	}
+}
+
+func TestLoadUsesDefaultOrganizationFromDotEnv(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_ORG", "HCPTF_ORG")
+	home := t.TempDir()
+	dir := t.TempDir()
+	chdir(t, dir)
+	t.Setenv("HOME", home)
+	writeFile(t, filepath.Join(dir, ".env"), "TFE_ORG=dotenv-org\n")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.DefaultOrganization != "dotenv-org" {
+		t.Fatalf("expected default organization dotenv-org, got %s", cfg.DefaultOrganization)
+	}
+}
+
+func TestLoadEnvironmentOrganizationOverridesConfig(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_ORG", "HCPTF_ORG")
+	home := t.TempDir()
+	chdir(t, t.TempDir())
+	t.Setenv("HOME", home)
+	t.Setenv("TFE_ORG", "env-org")
+
+	writeFile(t, filepath.Join(home, ".hcptfrc"), `
+default_organization = "config-org"
+`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.DefaultOrganization != "env-org" {
+		t.Fatalf("expected default organization env-org, got %s", cfg.DefaultOrganization)
 	}
 }
 
@@ -226,7 +269,9 @@ func TestLoadDotEnvMalformedFileReturnsError(t *testing.T) {
 }
 
 func TestLoadInvalidTerraformCredentialsReturnsError(t *testing.T) {
+	unsetEnv(t, EnvFileVariable)
 	home := t.TempDir()
+	chdir(t, t.TempDir())
 	t.Setenv("HOME", home)
 
 	writeFile(t, filepath.Join(home, ".terraform.d", "credentials.tfrc.json"), `{"credentials": invalid-json}`)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,51 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to change working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	})
+}
+
+func unsetEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	previous := make(map[string]string, len(keys))
+	present := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		if ok {
+			previous[key] = value
+			present[key] = true
+		}
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("failed to unset %s: %v", key, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, key := range keys {
+			var err error
+			if present[key] {
+				err = os.Setenv(key, previous[key])
+			} else {
+				err = os.Unsetenv(key)
+			}
+			if err != nil {
+				t.Fatalf("failed to restore %s: %v", key, err)
+			}
+		}
+	})
+}
+
 func TestLoadMergesConfigAndTerraformCredentials(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -79,6 +124,104 @@ func TestLoadDefaultsWhenConfigMissing(t *testing.T) {
 
 	if len(cfg.Credentials) != 0 {
 		t.Fatalf("expected no credentials, got %d", len(cfg.Credentials))
+	}
+}
+
+func TestLoadDotEnvLoadsDefaultFile(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN", "HCPTF_TOKEN", "TFE_ADDRESS", "HCPTF_ADDRESS")
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, filepath.Join(dir, ".env"), `
+# Terraform Enterprise connection
+TFE_TOKEN=dotenv-token
+TFE_ADDRESS=https://tfe.example.com
+`)
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+
+	if got := os.Getenv("TFE_TOKEN"); got != "dotenv-token" {
+		t.Fatalf("expected TFE_TOKEN from .env, got %q", got)
+	}
+	if got := os.Getenv("TFE_ADDRESS"); got != "https://tfe.example.com" {
+		t.Fatalf("expected TFE_ADDRESS from .env, got %q", got)
+	}
+}
+
+func TestLoadDotEnvDoesNotOverrideExistingEnvironment(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, filepath.Join(dir, ".env"), "TFE_TOKEN=dotenv-token\n")
+	t.Setenv("TFE_TOKEN", "exported-token")
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+
+	if got := os.Getenv("TFE_TOKEN"); got != "exported-token" {
+		t.Fatalf("expected exported TFE_TOKEN to win, got %q", got)
+	}
+}
+
+func TestLoadDotEnvExplicitFileTakesPrecedenceOverDefaultFile(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, filepath.Join(dir, ".env"), "TFE_TOKEN=default-token\n")
+	explicitPath := filepath.Join(dir, "prod.env")
+	writeFile(t, explicitPath, "TFE_TOKEN=explicit-token\n")
+	t.Setenv(EnvFileVariable, explicitPath)
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+
+	if got := os.Getenv("TFE_TOKEN"); got != "explicit-token" {
+		t.Fatalf("expected explicit env file token to win, got %q", got)
+	}
+}
+
+func TestLoadDotEnvMissingDefaultFileIsIgnored(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	if err := LoadDotEnv(); err != nil {
+		t.Fatalf("LoadDotEnv() error = %v", err)
+	}
+}
+
+func TestLoadDotEnvMissingExplicitFileReturnsError(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	dir := t.TempDir()
+	chdir(t, dir)
+	t.Setenv(EnvFileVariable, filepath.Join(dir, "missing.env"))
+
+	err := LoadDotEnv()
+	if err == nil {
+		t.Fatal("expected missing explicit env file to return error")
+	}
+	if !strings.Contains(err.Error(), "failed to load env file") {
+		t.Fatalf("expected env file error, got %v", err)
+	}
+}
+
+func TestLoadDotEnvMalformedFileReturnsError(t *testing.T) {
+	unsetEnv(t, EnvFileVariable, "TFE_TOKEN")
+	dir := t.TempDir()
+	chdir(t, dir)
+	envPath := filepath.Join(dir, "bad.env")
+	writeFile(t, envPath, "not valid dotenv\n")
+	t.Setenv(EnvFileVariable, envPath)
+
+	err := LoadDotEnv()
+	if err == nil {
+		t.Fatal("expected malformed env file to return error")
+	}
+	if !strings.Contains(err.Error(), "failed to load env file") {
+		t.Fatalf("expected env file error, got %v", err)
 	}
 }
 

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+const EnvFileVariable = "HCPTF_ENV_FILE"
+
+// LoadDotEnv loads connection settings from an explicit env file or a default
+// .env in the current working directory. Existing environment variables win.
+func LoadDotEnv() error {
+	if path := os.Getenv(EnvFileVariable); path != "" {
+		return LoadDotEnvFile(path)
+	}
+
+	if _, err := os.Stat(".env"); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat .env: %w", err)
+	}
+
+	return LoadDotEnvFile(".env")
+}
+
+// LoadDotEnvFile loads variables from path without overriding exported env vars.
+func LoadDotEnvFile(path string) error {
+	if err := godotenv.Load(path); err != nil {
+		return fmt.Errorf("failed to load env file %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -4,27 +4,43 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/joho/godotenv"
 )
 
 const EnvFileVariable = "HCPTF_ENV_FILE"
+const DisableEnvFileVariable = "HCPTF_DISABLE_ENV_FILE"
 
 // LoadDotEnv loads connection settings from an explicit env file or a default
-// .env in the current working directory. Existing environment variables win.
+// .env in the current working directory, ancestor directories, or user-level
+// hcptf env files. Existing environment variables win.
 func LoadDotEnv() error {
+	if os.Getenv(DisableEnvFileVariable) != "" {
+		return nil
+	}
+
 	if path := os.Getenv(EnvFileVariable); path != "" {
 		return LoadDotEnvFile(path)
 	}
 
-	if _, err := os.Stat(".env"); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
+	for _, path := range DotEnvCandidatePaths() {
+		info, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("failed to stat env file %q: %w", path, err)
 		}
-		return fmt.Errorf("failed to stat .env: %w", err)
+		if info.IsDir() {
+			continue
+		}
+		if err := LoadDotEnvFile(path); err != nil {
+			return err
+		}
 	}
 
-	return LoadDotEnvFile(".env")
+	return nil
 }
 
 // LoadDotEnvFile loads variables from path without overriding exported env vars.
@@ -33,4 +49,41 @@ func LoadDotEnvFile(path string) error {
 		return fmt.Errorf("failed to load env file %q: %w", path, err)
 	}
 	return nil
+}
+
+// DotEnvCandidatePaths returns env files from highest to lowest precedence.
+// godotenv.Load preserves existing variables, so loading in this order lets
+// project-specific files win while still allowing user-level defaults.
+func DotEnvCandidatePaths() []string {
+	seen := map[string]struct{}{}
+	var paths []string
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		cleaned := filepath.Clean(path)
+		if _, ok := seen[cleaned]; ok {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		paths = append(paths, cleaned)
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		home, _ := os.UserHomeDir()
+		for {
+			add(filepath.Join(cwd, ".env"))
+			if cwd == home || cwd == filepath.Dir(cwd) {
+				break
+			}
+			cwd = filepath.Dir(cwd)
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		add(filepath.Join(home, ".hcptf.env"))
+		add(filepath.Join(home, ".config", "hcptf", "env"))
+	}
+
+	return paths
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+binary := "hcptf"
+install_dir := env_var_or_default("PREFIX", env_var("HOME") + "/.local") + "/bin"
+
+default:
+    @just --list
+
+build:
+    go build -o {{binary}} .
+
+install: build
+    install -d {{install_dir}}
+    install -m 0755 {{binary}} {{install_dir}}/{{binary}}
+
+test:
+    go test ./...

--- a/main.go
+++ b/main.go
@@ -54,8 +54,14 @@ func realMain() int {
 	commandPaths := extractCommandPaths(commands)
 	getVerbIndex := buildGetVerbIndex(commands)
 
+	// Parse global flags that must be handled before command routing.
+	args, err := extractEnvFileFlag(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing arguments: %s\n", err.Error())
+		return 1
+	}
+
 	// Translate URL-like args if present
-	args := os.Args[1:]
 	r := router.NewRouter(nil, commandPaths) // Pass nil client for now - we don't need validation
 	translatedArgs, err := r.TranslateArgs(args)
 	if err != nil {
@@ -86,6 +92,44 @@ func realMain() int {
 	}
 
 	return exitCode
+}
+
+func extractEnvFileFlag(args []string) ([]string, error) {
+	out := make([]string, 0, len(args))
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--env-file" || arg == "-env-file":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return nil, fmt.Errorf("%s requires a path", arg)
+			}
+			if err := os.Setenv("HCPTF_ENV_FILE", args[i+1]); err != nil {
+				return nil, err
+			}
+			i++
+		case strings.HasPrefix(arg, "--env-file="):
+			path := strings.TrimPrefix(arg, "--env-file=")
+			if path == "" {
+				return nil, fmt.Errorf("--env-file requires a path")
+			}
+			if err := os.Setenv("HCPTF_ENV_FILE", path); err != nil {
+				return nil, err
+			}
+		case strings.HasPrefix(arg, "-env-file="):
+			path := strings.TrimPrefix(arg, "-env-file=")
+			if path == "" {
+				return nil, fmt.Errorf("-env-file requires a path")
+			}
+			if err := os.Setenv("HCPTF_ENV_FILE", path); err != nil {
+				return nil, err
+			}
+		default:
+			out = append(out, arg)
+		}
+	}
+
+	return out, nil
 }
 
 // GetVersion returns the full version string

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -61,6 +62,68 @@ func TestGetVersion_CurrentValues(t *testing.T) {
 
 	if Version == "" {
 		t.Error("Version global variable is empty")
+	}
+}
+
+func TestExtractEnvFileFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		expected    []string
+		expectedEnv string
+		expectErr   bool
+	}{
+		{
+			name:        "long flag with separate value",
+			input:       []string{"--env-file", ".env.prod", "whoami"},
+			expected:    []string{"whoami"},
+			expectedEnv: ".env.prod",
+		},
+		{
+			name:        "long flag with equals value",
+			input:       []string{"whoami", "--env-file=.env.prod"},
+			expected:    []string{"whoami"},
+			expectedEnv: ".env.prod",
+		},
+		{
+			name:        "single dash flag with separate value",
+			input:       []string{"-env-file", ".env.prod", "workspace", "list"},
+			expected:    []string{"workspace", "list"},
+			expectedEnv: ".env.prod",
+		},
+		{
+			name:      "missing value errors",
+			input:     []string{"--env-file"},
+			expectErr: true,
+		},
+		{
+			name:      "empty equals value errors",
+			input:     []string{"--env-file="},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HCPTF_ENV_FILE", "")
+
+			got, err := extractEnvFileFlag(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("extractEnvFileFlag(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+			if gotEnv := os.Getenv("HCPTF_ENV_FILE"); gotEnv != tt.expectedEnv {
+				t.Fatalf("expected HCPTF_ENV_FILE %q, got %q", tt.expectedEnv, gotEnv)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds local dotenv-based configuration defaults for hcptf, including project and user-level env file discovery, an explicit `--env-file` / `HCPTF_ENV_FILE` override, and `TFE_ORG` / `HCPTF_ORG` as a default organization source.

Also adds a `justfile` with common build/install/test recipes and updates authentication documentation plus `.env.example`.

## Impact

Users can keep local HCP Terraform connection settings in ignored env files while exported environment variables continue to take precedence. Commands that accept organization flags can now use the configured default organization when the flag is omitted.

## Validation

Automated checks run locally:

```text
$ go build -o hcptf .
# exits 0

$ go test ./...
ok  	github.com/hashicorp/hcptf-cli	(cached)
ok  	github.com/hashicorp/hcptf-cli/command	(cached)
ok  	github.com/hashicorp/hcptf-cli/internal/client	(cached)
ok  	github.com/hashicorp/hcptf-cli/internal/config	(cached)
ok  	github.com/hashicorp/hcptf-cli/internal/output	(cached)
ok  	github.com/hashicorp/hcptf-cli/internal/router	(cached)
ok  	github.com/hashicorp/hcptf-cli/internal/validate	(cached)
```

Justfile discovery:

```text
$ just --list
Available recipes:
    build
    default
    install
    test
```

Manual dotenv validation was run with an isolated temporary `HOME` and dry-run CLI calls, so no real local credentials or API writes were used.

Explicit `--env-file` populates the default organization:

```text
$ env -i PATH="$PATH" HOME="$TMP/home" ./hcptf --env-file "$TMP/explicit.env" agentpool create -name manual-pool -dry-run
{
  "action": "create",
  "options": {
    "Type": "",
    "Name": "manual-pool",
    "OrganizationScoped": false,
    "AllowedWorkspaces": null,
    "AllowedProjects": null,
    "ExcludedWorkspaces": null
  },
  "organization": "explicit-org",
  "resource": "agentpool"
}
```

Exported environment variables override env-file values:

```text
$ env -i PATH="$PATH" HOME="$TMP/home" TFE_ORG=exported-org ./hcptf --env-file "$TMP/override.env" agentpool create -name manual-pool -dry-run
{
  "action": "create",
  "options": {
    "Type": "",
    "Name": "manual-pool",
    "OrganizationScoped": false,
    "AllowedWorkspaces": null,
    "AllowedProjects": null,
    "ExcludedWorkspaces": null
  },
  "organization": "exported-org",
  "resource": "agentpool"
}
```

Ancestor `.env` discovery works from a nested working directory:

```text
$ (cd "$TMP/project/nested" && env -i PATH="$PATH" HOME="$TMP/home" ./hcptf agentpool create -name manual-pool -dry-run)
{
  "action": "create",
  "options": {
    "Type": "",
    "Name": "manual-pool",
    "OrganizationScoped": false,
    "AllowedWorkspaces": null,
    "AllowedProjects": null,
    "ExcludedWorkspaces": null
  },
  "organization": "ancestor-org",
  "resource": "agentpool"
}
```

Disabling env-file loading leaves `-organization` required:

```text
$ (cd "$TMP/project/nested" && env -i PATH="$PATH" HOME="$TMP/home" HCPTF_DISABLE_ENV_FILE=1 ./hcptf agentpool create -name manual-pool -dry-run)
Error: -organization flag is required
...
exit_status=1
```

GitHub checks observed after opening the PR:

```text
CI / gofmt: success
CI / test: success
Changelog / verify: failure
```
